### PR TITLE
Explicitly prohibit building on Windows and macOS

### DIFF
--- a/tasty-papi.cabal
+++ b/tasty-papi.cabal
@@ -39,6 +39,9 @@ Library
   extra-libraries: papi
   Exposed-modules: Test.Tasty.PAPI
 
+  if(os(darwin) || os(windows))
+    buildable: False
+
 test-suite tasty-papi-run
   default-language: Haskell2010
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
I spent some time trying `brew install libpapi`, `port install libpapi` and even downloading sources, before realising that it's impossible.